### PR TITLE
Adding a github action for testing and ensuring the coq spec builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,29 +24,47 @@ jobs:
       - name: Setup pre-deps
         run: sudo apt install libgtk-3-0 libgtk-3-dev libgtksourceview-3.0-common libgtksourceview-3.0-dev opam
 
+############### OPAM STEPS
+      - name: Restore Opam Cache
+        id: opam-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.opam
+          key: ${{ runner.OS }}-OPAM-$OCAML_VERSION
+          restore-key: ${{ runner.OS }}-OPAM-
+      
+      - name: Opam Setup
+        if: steps.opam-cache-restore.outputs.cache-hit != 'true'
+        run: |
+          opam init
+          opam install -y dune coq lablgtk3-sourceview3
+      
+      - name: Opam Cache Installs
+        id: opam-cache-install
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.opam
+          key: ${{ runner.OS }}-OPAM-$OCAML_VERSION
+
+############### COQ STEPS
       - name: Get latest commit hash of Coq Repo
         id: get_commit_hash
         run: |
           response=$(curl -s "https://api.github.com/repos/$COQ_REPO_PATH/commits/$COQ_REPO_BRANCH")
           commit_hash=$(echo "$response" | jq -r '.sha')
           echo "COMMIT_HASH=$commit_hash" >> $GITHUB_ENV
-
-      - name: Restore Cached Install
-        id: cache-restore
+          
+      - name: Restore Coq Cache
+        id: coq-cache-restore
         uses: actions/cache/restore@v4
         with:
-          path: |
-            ~/.opam
-            ~/coq
-          key: ${{ runner.OS }}-$OCAML_VERSION-${{ env.COMMIT_HASH }}
+          path: ~/coq
+          key: ${{ runner.OS }}-COQ-${{ env.COMMIT_HASH }}
+          restore-key: ${{ runner.OS }}-COQ-
       
-      - run: opam init
-      - run: opam install -y dune coq lablgtk3-sourceview3
-
 # We only need to setup the coq library again if it didnt get pulled from cache properly
-# TODO: Ultimately this should be dependent on if this repo changes, but not important for now
-      - name: Checkout and build external library
-        if: steps.cache-restore.outputs.cache-hit != 'true'
+      - name: Checkout and build Coq
+        if: steps.coq-cache-restore.outputs.cache-hit != 'true'
         run: |
           cd ~
           eval $(opam env)
@@ -55,15 +73,14 @@ jobs:
           git switch $COQ_REPO_BRANCH
           make world
       
-      - name: Cache Installs
-        id: cache-install
+      - name: Coq Cache Installs
+        id: coq-cache-install
         uses: actions/cache/save@v4
         with:
-          path: |
-            ~/.opam
-            ~/coq
-          key: ${{ runner.OS }}-$OCAML_VERSION-${{ env.COMMIT_HASH }}
+          path: ~/coq
+          key: ${{ runner.OS }}-COQ-${{ env.COMMIT_HASH }}
 
+############### Final Testing Copland-AVM steps
       - name: Checkout code
         uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
             
       - name: Checkout and build external library
         run: |
-          eval $(opam env --switch=default)
+          eval $(opam env)
           git clone https://github.com/ku-sldg/coq.git
           cd coq
           git switch cakeml-extraction

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,9 +50,9 @@ jobs:
           git clone https://github.com/ku-sldg/coq.git
           cd coq
           git switch cakeml-extraction
-          make coq-core.install
-          make coq-stdlib.install
-          make coq.install
+          dune build coq-core.install
+          dune build coq-stdlib.install
+          dune build coq.install
           cd ..
       
       - name: Cache Installs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,19 +12,24 @@ jobs:
   build-and-test:
     strategy:
       fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-        ocaml-compiler:
-          - "4.14.1"
-        coq-repo-url:
-          - "https://github.com/ku-sldg/coq.git"
+      
+    runs-on: ubuntu-latest
 
-    runs-on: ${{ matrix.os }}
+    env:
+      COQ_REPO_PATH: "ku-sldg/coq"
+      OCAML_VERSION: "4.14.1"
+      COQ_REPO_BRANCH: "cakeml-extraction"
 
     steps:
       - name: Setup pre-deps
         run: sudo apt install libgtk-3-0 libgtk-3-dev libgtksourceview-3.0-common libgtksourceview-3.0-dev opam
+
+      - name: Get latest commit hash of Coq Repo
+        id: get_commit_hash
+        run: |
+          response=$(curl -s "https://api.github.com/repos/$COQ_REPO_PATH/commits/$COQ_REPO_BRANCH")
+          commit_hash=$(echo "$response" | jq -r '.sha')
+          echo "COMMIT_HASH=$commit_hash" >> $GITHUB_ENV
 
       - name: Restore Cached Install
         id: cache-restore
@@ -33,7 +38,7 @@ jobs:
           path: |
             ~/.opam
             ~/coq
-          key: ${{ runner.OS }}-${{ matrix.ocaml-compiler }}
+          key: ${{ runner.OS }}-$OCAML_VERSION-${{ env.COMMIT_HASH }}
       
       - run: opam init
       - run: opam install -y dune coq lablgtk3-sourceview3
@@ -45,9 +50,9 @@ jobs:
         run: |
           cd ~
           eval $(opam env)
-          git clone ${{ matrix.coq-repo-url }}
+          git clone https://github.com/$COQ_REPO_URL.git
           cd coq
-          git switch cakeml-extraction
+          git switch $COQ_REPO_BRANCH
           make world
       
       - name: Cache Installs
@@ -57,7 +62,7 @@ jobs:
           path: |
             ~/.opam
             ~/coq
-          key: ${{ runner.OS }}-${{ matrix.ocaml-compiler }}
+          key: ${{ runner.OS }}-$OCAML_VERSION-${{ env.COMMIT_HASH }}
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cd ~
           eval $(opam env)
-          git clone https://github.com/$COQ_REPO_URL.git
+          git clone https://github.com/$COQ_REPO_PATH.git
           cd coq
           git switch $COQ_REPO_BRANCH
           make world

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
           eval $(opam env)
           git clone ${{ matrix.coq-repo-url }}
           cd coq
-          echo "DIRECTORY_PATH=$(pwd)" >> $GITHUB_ENV
+          echo "DIRECTORY_PATH=$(pwd)" >> $ENV
           echo "Directory path is $DIRECTORY_PATH"
           pwd
           git switch cakeml-extraction
@@ -69,6 +69,9 @@ jobs:
       - name: Test Build
         run: |
           pwd
+          echo $COQBIN
+          export COQBINN=~/coq/_build/install/default/bin/
+          echo $COQBINN
           cd ${{ github.workspace }}/src
           $COQBIN/coq_makefile -f _CoqProject -o MAKEPRIME
           make -f MAKEPRIME

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,45 +20,49 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    cache:
-      directories:
-        - ~/.opam
-        - ~/coq
-
     steps:
       - name: Setup pre-deps
-        run: sudo apt install libgtk-3-0 libgtk-3-dev libgtksourceview-3.0-common libgtksourceview-3.0-dev
-        
-#      - name: Restore Cached OCaml Install
-#        id: cache-ocaml-restore
-#        uses: actions/cache/restore@v4
-#        with:
-#          path: ~/.opam
-#          key: ${{ runner.OS }}-${{ matrix.ocaml-compiler }}
-    
-      - name: Setup Ocaml ${{ matrix.ocaml-compiler }}
-#        if: steps.cache-ocaml-restore.outputs.cache-hit != 'true'
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+        run: sudo apt install opam
 
-      - run: opam install -y dune coq lablgtk3-sourceview3
-      
-#      - name: Cache OCaml install
-#        id: cache-ocaml-install
-#        uses: actions/cache/save@v4
+      - run: opam init
+        
+      - name: Restore Cached Install
+        id: cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.opam
+            ~/coq
+          key: ${{ runner.OS }}-${{ matrix.ocaml-compiler }}
+    
+#      - name: Setup Ocaml ${{ matrix.ocaml-compiler }}
+#        if: steps.cache-ocaml-restore.outputs.cache-hit != 'true'
+#        uses: ocaml/setup-ocaml@v2
 #        with:
-#          path: ~/.opam
-#          key: ${{ runner.OS }}-${{ matrix.ocaml-compiler }}
-            
+#          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - run: opam install -y dune
+
+# NONDOC_INSTALL_TARGETS:=coq-core.install coq-stdlib.install coqide-server.install coqide.install coq.install
       - name: Checkout and build external library
         run: |
           eval $(opam env)
           git clone https://github.com/ku-sldg/coq.git
           cd coq
           git switch cakeml-extraction
-          make world
+          make coq-core.install
+          make coq-stdlib.install
+          make coq.install
           cd ..
+      
+      - name: Cache Installs
+        id: cache-install
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.opam
+            ~/coq
+          key: ${{ runner.OS }}-${{ matrix.ocaml-compiler }}
 
       - name: Setup Coq Bin Path
         run: export COQBIN=~/coq/_build/install/default/bin/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,49 @@
+name: Build and Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        ocaml-compiler:
+          - "4.14.1"
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Setup Ocaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - run: opam install -y dune, coq, lablgtk3-sourceview3
+
+      - name: Checkout and build external library
+        run: |
+          git clone https://github.com/ku-sldg/coq.git
+          cd coq
+          git switch cakeml-extraction
+          make world
+          cd ..
+
+      - name: Setup Coq Bin Path
+        run: export COQBIN=~/coq/_build/install/default/bin/
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Test Build
+        run: |
+          cd copland-avm/src
+          $COQBIN/coq_makefile -f _CoqProject -o MAKEPRIME
+          make -f MAKEPRIME

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,31 +20,36 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    cache:
+      directories:
+        - ~/.opam
+        - ~/coq
+
     steps:
       - name: Setup pre-deps
         run: sudo apt install libgtk-3-0 libgtk-3-dev libgtksourceview-3.0-common libgtksourceview-3.0-dev
         
-      - name: Restore Cached OCaml Install
-        id: cache-ocaml-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.opam
-          key: ${{ runner.OS }}-${{ matrix.ocaml-compiler }}
+#      - name: Restore Cached OCaml Install
+#        id: cache-ocaml-restore
+#        uses: actions/cache/restore@v4
+#        with:
+#          path: ~/.opam
+#          key: ${{ runner.OS }}-${{ matrix.ocaml-compiler }}
     
       - name: Setup Ocaml ${{ matrix.ocaml-compiler }}
-        if: steps.cache-ocaml-restore.outputs.cache-hit != 'true'
+#        if: steps.cache-ocaml-restore.outputs.cache-hit != 'true'
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
       - run: opam install -y dune coq lablgtk3-sourceview3
       
-      - name: Cache OCaml install
-        id: cache-ocaml-install
-        uses: actions/cache/save@v4
-        with:
-          path: ~/.opam
-          key: ${{ runner.OS }}-${{ matrix.ocaml-compiler }}
+#      - name: Cache OCaml install
+#        id: cache-ocaml-install
+#        uses: actions/cache/save@v4
+#        with:
+#          path: ~/.opam
+#          key: ${{ runner.OS }}-${{ matrix.ocaml-compiler }}
             
       - name: Checkout and build external library
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,6 @@ jobs:
 
       - name: Test Build
         run: |
-          cd copland-avm/src
+          cd ~/copland-avm/src
           $COQBIN/coq_makefile -f _CoqProject -o MAKEPRIME
           make -f MAKEPRIME

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Setup pre-deps
-        run: sudo apt install opam
+        run: sudo apt install libgtk-3-0 libgtk-3-dev libgtksourceview-3.0-common libgtksourceview-3.0-dev
 
       - run: opam init
         
@@ -41,7 +41,7 @@ jobs:
 #        with:
 #          ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - run: opam install -y dune
+      - run: opam install -y dune coq lablgtk3-sourceview3
 
 # NONDOC_INSTALL_TARGETS:=coq-core.install coq-stdlib.install coqide-server.install coqide.install coq.install
       - name: Checkout and build external library
@@ -50,9 +50,7 @@ jobs:
           git clone https://github.com/ku-sldg/coq.git
           cd coq
           git switch cakeml-extraction
-          dune build coq-core.install
-          dune build coq-stdlib.install
-          dune build coq.install
+          make world
           cd ..
       
       - name: Cache Installs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Setup pre-deps
-        run: apt-get install libgtk-3-dev
+        run: sudo apt install libgtk-3-0 libgtk-3-dev
 
       - name: Setup Ocaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,18 +38,17 @@ jobs:
       - run: opam init
       - run: opam install -y dune coq lablgtk3-sourceview3
 
+# We only need to setup the coq library again if it didnt get pulled from cache properly
+# TODO: Ultimately this should be dependent on if this repo changes, but not important for now
       - name: Checkout and build external library
+        if: steps.cache-restore.outputs.cache-hit != 'true'
         run: |
           cd ~
           eval $(opam env)
           git clone ${{ matrix.coq-repo-url }}
           cd coq
-          export DIRECTORY_PATH=$(pwd)
-          echo "Directory path is $DIRECTORY_PATH"
-          pwd
           git switch cakeml-extraction
           make world
-          cd ..
       
       - name: Cache Installs
         id: cache-install
@@ -60,18 +59,13 @@ jobs:
             ~/coq
           key: ${{ runner.OS }}-${{ matrix.ocaml-compiler }}
 
-      - name: Setup Coq Bin Path
-        run: export COQBIN=~/coq/_build/install/default/bin/
-
       - name: Checkout code
         uses: actions/checkout@v2
 
       - name: Test Build
         run: |
-          pwd
-          echo $COQBIN
-          export COQBINN=~/coq/_build/install/default/bin/
-          echo $COQBINN
+          export COQBIN=~/coq/_build/install/default/bin/
+          echo "COQBIN is $COQBIN"
           cd ${{ github.workspace }}/src
           $COQBIN/coq_makefile -f _CoqProject -o MAKEPRIME
           make -f MAKEPRIME

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,9 @@ jobs:
           opam init
           opam install -y dune coq lablgtk3-sourceview3
       
-      - name: Opam Cache Installs
+      - name: Opam Cache Save
         id: opam-cache-install
+        if: steps.opam-cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: ~/.opam
@@ -73,8 +74,9 @@ jobs:
           git switch $COQ_REPO_BRANCH
           make world
       
-      - name: Coq Cache Installs
+      - name: Coq Cache Save
         id: coq-cache-install
+        if: steps.coq-cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: ~/coq

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ jobs:
           - ubuntu-latest
         ocaml-compiler:
           - "4.14.1"
+        coq-repo-url:
+          - "https://github.com/ku-sldg/coq.git"
 
     runs-on: ${{ matrix.os }}
 
@@ -24,8 +26,6 @@ jobs:
       - name: Setup pre-deps
         run: sudo apt install libgtk-3-0 libgtk-3-dev libgtksourceview-3.0-common libgtksourceview-3.0-dev opam
 
-      - run: opam init
-        
       - name: Restore Cached Install
         id: cache-restore
         uses: actions/cache/restore@v4
@@ -34,21 +34,19 @@ jobs:
             ~/.opam
             ~/coq
           key: ${{ runner.OS }}-${{ matrix.ocaml-compiler }}
-    
-#      - name: Setup Ocaml ${{ matrix.ocaml-compiler }}
-#        if: steps.cache-ocaml-restore.outputs.cache-hit != 'true'
-#        uses: ocaml/setup-ocaml@v2
-#        with:
-#          ocaml-compiler: ${{ matrix.ocaml-compiler }}
-
+      
+      - run: opam init
       - run: opam install -y dune coq lablgtk3-sourceview3
 
-# NONDOC_INSTALL_TARGETS:=coq-core.install coq-stdlib.install coqide-server.install coqide.install coq.install
       - name: Checkout and build external library
         run: |
+          cd ~
           eval $(opam env)
-          git clone https://github.com/ku-sldg/coq.git
+          git clone ${{ matrix.coq-repo-url }}
           cd coq
+          echo "DIRECTORY_PATH=$(pwd)" >> $GITHUB_ENV
+          echo "Directory path is $DIRECTORY_PATH"
+          pwd
           git switch cakeml-extraction
           make world
           cd ..
@@ -70,6 +68,7 @@ jobs:
 
       - name: Test Build
         run: |
+          pwd
           cd ${{ github.workspace }}/src
           $COQBIN/coq_makefile -f _CoqProject -o MAKEPRIME
           make -f MAKEPRIME

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,16 +22,14 @@ jobs:
 
     steps:
       - name: Setup pre-deps
-        run: sudo apt install libgtk-3-0 libgtk-3-dev
+        run: sudo apt install libgtk-3-0 libgtk-3-dev libgtksourceview-3.0-common libgtksourceview-3.0-dev
 
       - name: Setup Ocaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - run: opam install -y dune 
-      - run: opam install -y coq 
-      - run: opam install -y lablgtk3-sourceview3
+      - run: opam install -y dune coq lablgtk3-sourceview3
       
       - name: Cache OCaml install
         uses: actions/cache@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Setup pre-deps
+        run: apt-get install libgtk-3-dev
+
       - name: Setup Ocaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,13 +26,15 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - run: opam install -y dune coq lablgtk3-sourceview3
+      - run: opam install -y dune 
+      - run: opam install -y coq 
+      - run: opam install -y lablgtk3-sourceview3
       
       - name: Cache OCaml install
         uses: actions/cache@v3
         with:
           path: ~/.opam
-          key: ${{ runner.OS }}
+          key: ${{ runner.OS }}-${{ matrix.ocaml-compiler }}
             
       - name: Checkout and build external library
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Setup pre-deps
-        run: sudo apt install libgtk-3-0 libgtk-3-dev libgtksourceview-3.0-common libgtksourceview-3.0-dev
+        run: sudo apt install libgtk-3-0 libgtk-3-dev libgtksourceview-3.0-common libgtksourceview-3.0-dev ppam
 
       - run: opam init
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           path: ~/.opam
           key: ${{ runner.OS }}-OPAM-$OCAML_VERSION
-          restore-key: ${{ runner.OS }}-OPAM-
+          restore-keys: ${{ runner.OS }}-OPAM-
       
       - name: Opam Setup
         if: steps.opam-cache-restore.outputs.cache-hit != 'true'
@@ -60,7 +60,7 @@ jobs:
         with:
           path: ~/coq
           key: ${{ runner.OS }}-COQ-${{ env.COMMIT_HASH }}
-          restore-key: ${{ runner.OS }}-COQ-
+          restore-keys: ${{ runner.OS }}-COQ-
       
 # We only need to setup the coq library again if it didnt get pulled from cache properly
       - name: Checkout and build Coq

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,16 @@ jobs:
     steps:
       - name: Setup pre-deps
         run: sudo apt install libgtk-3-0 libgtk-3-dev libgtksourceview-3.0-common libgtksourceview-3.0-dev
-
+        
+      - name: Restore Cached OCaml Install
+        id: cache-ocaml-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.opam
+          key: ${{ runner.OS }}-${{ matrix.ocaml-compiler }}
+    
       - name: Setup Ocaml ${{ matrix.ocaml-compiler }}
+        if: steps.cache-ocaml-restore.outputs.cache-hit != 'true'
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
@@ -32,7 +40,8 @@ jobs:
       - run: opam install -y dune coq lablgtk3-sourceview3
       
       - name: Cache OCaml install
-        uses: actions/cache@v3
+        id: cache-ocaml-install
+        uses: actions/cache/save@v4
         with:
           path: ~/.opam
           key: ${{ runner.OS }}-${{ matrix.ocaml-compiler }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
             
       - name: Checkout and build external library
         run: |
+          eval $(opam env --switch=default)
           git clone https://github.com/ku-sldg/coq.git
           cd coq
           git switch cakeml-extraction

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
           eval $(opam env)
           git clone ${{ matrix.coq-repo-url }}
           cd coq
-          echo "DIRECTORY_PATH=$(pwd)" >> $ENV
+          export DIRECTORY_PATH=$(pwd)
           echo "Directory path is $DIRECTORY_PATH"
           pwd
           git switch cakeml-extraction

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,6 @@ jobs:
 
       - name: Test Build
         run: |
-          cd ~/copland-avm/src
+          cd ${{ github.workspace }}/src
           $COQBIN/coq_makefile -f _CoqProject -o MAKEPRIME
           make -f MAKEPRIME

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Setup pre-deps
-        run: sudo apt install libgtk-3-0 libgtk-3-dev libgtksourceview-3.0-common libgtksourceview-3.0-dev ppam
+        run: sudo apt install libgtk-3-0 libgtk-3-dev libgtksourceview-3.0-common libgtksourceview-3.0-dev opam
 
       - run: opam init
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,14 @@ jobs:
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 
-      - run: opam install -y dune, coq, lablgtk3-sourceview3
-
+      - run: opam install -y dune coq lablgtk3-sourceview3
+      
+      - name: Cache OCaml install
+        uses: actions/cache@v3
+        with:
+          path: ~/.opam
+          key: ${{ runner.OS }}
+            
       - name: Checkout and build external library
         run: |
           git clone https://github.com/ku-sldg/coq.git


### PR DESCRIPTION
This action has a couple variables involved:
- a URL to point to a repo of Coq we want to experimentally use
- a branch name for the repo
- the version of OCaml we are compiling with

This action will cache the OPAM state, and the Coq state. Only modifying them if the OCaml compiler version changes, or if the Coq repo's most recent commit hash differs.

This action should ultimately be utilized to determine if a branch is suitable for merging into master