### PR TITLE
Updating makefile to utilize custom coq via COQBIN env var

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,5 +91,4 @@ jobs:
           export COQBIN=~/coq/_build/install/default/bin/
           echo "COQBIN is $COQBIN"
           cd ${{ github.workspace }}/src
-          $COQBIN/coq_makefile -f _CoqProject -o MAKEPRIME
-          make -f MAKEPRIME
+          make 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    - cron: '0 0 * * 0' # Running at midnight every Sunday (to preserve caches mostly)
 
 jobs:
   build-and-test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.opam
-          key: ${{ runner.OS }}-OPAM-$OCAML_VERSION
+          key: ${{ runner.OS }}-OPAM-${{ env.OCAML_VERSION }}
           restore-keys: ${{ runner.OS }}-OPAM-
       
       - name: Opam Setup
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ~/.opam
-          key: ${{ runner.OS }}-OPAM-$OCAML_VERSION
+          key: ${{ runner.OS }}-OPAM-${{ env.OCAML_VERSION }}
 
 ############### COQ STEPS
       - name: Get latest commit hash of Coq Repo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
 
 ############### Final Testing Copland-AVM steps
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Test Build
         run: |

--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ To compile all the proof script dependencies in `src/` and step through them int
     * Note:  Make sure this is a LOCAL install (and NOT one installed globally via opam).  This should require:
         * gathering dependencies as specified [here](https://github.com/ku-sldg/coq/blob/cakeml-extraction/INSTALL.md#build-requirements), then 
         *  Inside `<CoqPath>`/coq (top-level of forked Coq repo) run:   `make world`
-        *  Add `<CoqPath>/coq/_build/install/default/bin` to your PATH environment variable
-        *  Set the COQLIB environment variable to `<CoqPath>/coq/_build/install/default/lib/coq`
-        * IMPORTANT:  hide any previous opam-installed versions.  This usually requires deleting a line in your ~/.bashrc (or equivalent) that auto-loads opam tools for each new terminal session.
+        *  **Path Level Configuration**
+			* Add `<CoqPath>/coq/_build/install/default/bin` to your PATH environment variable
+        	* Set the COQLIB environment variable to `<CoqPath>/coq/_build/install/default/lib/coq`
+        	* IMPORTANT:  hide any previous opam-installed versions.  This usually requires deleting a line in your ~/.bashrc (or equivalent) that auto-loads opam tools for each new terminal session.
+		* **Manual Configuration**
+			* Alternatively to adding the Coq install to your PATH, you can instead use `export COQBIN=<CoqPath>/coq/_build/install/default/bin` before running `make`
 1.  [VS Code](https://code.visualstudio.com/) (with VSCoq extension), [ProofGeneral](https://proofgeneral.github.io/), or your favorite Coq IDE
 
 Then type:  `cd src ; make`

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,12 +10,18 @@ PROJ	= _CoqProject
 # Generated makefile
 COQMK	= coq.mk
 
+COQBIN?=
+ifneq (,$(COQBIN))
+# add an ending /
+COQBIN:=$(COQBIN)/
+endif
+
 all:	$(COQMK)
 	$(MAKE) -f $(COQMK)
 	$(MAKE) -f $(COQMK) $(DOC)
 
 $(COQMK): $(PROJ)
-	coq_makefile -o $(COQMK) -f $(PROJ)
+	$(COQBIN)coq_makefile -o $(COQMK) -f $(PROJ)
 
 $(PROJ):
 	@echo make $@


### PR DESCRIPTION
This change should allow for easier switching between which version of Coq (TJs vs. normal) with just exporting a env variable before make.

**NOTE**: It does not break any current workflows, if you have Coq set in your global path instead this will still work, just easier for people who do not