### PR TITLE
Canonical Conversions for Strings and JSON

### DIFF
--- a/src/BS.v
+++ b/src/BS.v
@@ -2,11 +2,11 @@
    BS stands for "Binary String".  May be instantiated with 
    types like strings and byte buffers in concrete implementations.    *)
 
-Require Import ResultT Serializable. 
+Require Import ResultT Stringifiable. 
 
 Definition BS : Set. Admitted.
 
-Global Instance Serializable_BS : Serializable BS. Admitted.
+Global Instance Stringifiable_BS : Stringifiable BS. Admitted.
 
 (* Some default/reserved BS values *)
 Definition default_bs : BS. Admitted.

--- a/src/CvmJson_Interfaces.v
+++ b/src/CvmJson_Interfaces.v
@@ -3,7 +3,7 @@
     
     At the moment, these are too low-level to represent faithfully in the Coq development.   *)
 
-Require Import Term_Defs_Core Term_Defs List JSON Interface_Types ResultT ErrorStringConstants BS Serializable.
+Require Import Term_Defs_Core Term_Defs List JSON Interface_Types ResultT ErrorStringConstants BS Stringifiable.
 Export Interface_Types JSON.
 Import ListNotations ResultNotation.
 

--- a/src/Event_system.v
+++ b/src/Event_system.v
@@ -79,7 +79,7 @@ Section Event_system.
       well_structured es ->
       snd (es_range es) = fst (es_range es) + es_size es.
   Proof.
-    induction es; simpl; intros; inv H; simpl; auto;
+    induction es; simpl; intros; old_inv H; simpl; auto;
       try rewrite Nat.add_1_r; auto;
         apply IHes1 in H3;
         apply IHes2 in H4;
@@ -148,8 +148,8 @@ Section Event_system.
     clear G.
     revert H0.
     revert e.
-    induction es; intros; simpl in *; inv H; simpl in *;
-      inv H0; simpl; try lia.
+    induction es; intros; simpl in *; old_inv H; simpl in *;
+      old_inv H0; simpl; try lia.
     - apply IHes1 in H2; auto; lia.
     - apply IHes2 in H2; auto.
       apply well_structured_range in H4.
@@ -174,8 +174,8 @@ Section Event_system.
     revert ev1.
     revert ev0.
     induction H; intros; simpl in *.
-    - inv H1; inv H2; auto.
-    - inv H3; inv H4.
+    - old_inv H1; old_inv H2; auto.
+    - old_inv H3; old_inv H4.
       + eapply IHwell_structured1 in H8; eauto.
       + apply ws_evsys_range in H8; auto.
         apply ws_evsys_range in H6; auto.
@@ -184,7 +184,7 @@ Section Event_system.
         apply ws_evsys_range in H6; auto.
         lia.
       + eapply IHwell_structured2 in H8; eauto.
-    - inv H3; inv H4.
+    - old_inv H3; old_inv H4.
       + eapply IHwell_structured1 in H8; eauto.
       + apply ws_evsys_range in H8; auto.
         apply ws_evsys_range in H6; auto.
@@ -203,7 +203,7 @@ Section Event_system.
       well_structured es ->
       ~prec es ev ev.
   Proof.
-    induction es; intros; intro; inv H; inv H0.
+    induction es; intros; intro; old_inv H; old_inv H0.
     - apply ws_evsys_range in H8; auto.
       apply ws_evsys_range in H9; auto.
       lia.
@@ -221,10 +221,10 @@ Section Event_system.
       prec es ev0 ev2.
   Proof.
     induction es; intros.
-    - inv H0.
-    - inv H.
-      inv H0.
-      + inv H1.
+    - old_inv H0.
+    - old_inv H.
+      old_inv H0.
+      + old_inv H1.
         * apply ws_evsys_range in H10; auto.
         * apply prec_in_left in H7.
           apply ws_evsys_range in H7; auto.
@@ -233,13 +233,13 @@ Section Event_system.
         * apply prec_in_right in H7; auto.
       + assert (G: ev_in ev0 es1). apply prec_in_left in H9; auto.
         assert (F: ev_in ev1 es1). apply prec_in_right in H9; auto.
-        inv H1; auto.
+        old_inv H1; auto.
         eapply IHes1 in H7; eauto.
         apply prseq; auto.
         apply prec_in_right in H7; auto.
       + assert (G: ev_in ev0 es2). apply prec_in_left in H9; auto.
         assert (F: ev_in ev1 es2). apply prec_in_right in H9; auto.
-        inv H1.
+        old_inv H1.
         * apply ws_evsys_range in H7; auto.
           apply ws_evsys_range in F; auto.
           lia.
@@ -248,9 +248,9 @@ Section Event_system.
           apply ws_evsys_range in F; auto.
           lia.
         * eapply IHes2 in H7; eauto.
-    - inv H.
-      inv H0.
-      + inv H1.
+    - old_inv H.
+      old_inv H0.
+      + old_inv H1.
         * eapply IHes1 in H7; eauto.
         * apply prec_in_left in H7.
           apply prec_in_right in H9.
@@ -259,7 +259,7 @@ Section Event_system.
           lia.
       + assert (G: ev_in ev0 es2). apply prec_in_left in H9; auto.
         assert (F: ev_in ev1 es2). apply prec_in_right in H9; auto.
-        inv H1.
+        old_inv H1.
         * apply prec_in_left in H7.
           apply ws_evsys_range in H7; auto.
           apply ws_evsys_range in F; auto.
@@ -280,7 +280,7 @@ Section Event_system.
       well_structured (merge (fst r, snd s) x (merge s y z)).
   Proof.
     intros r s x y z Hr Hs.
-    inv Hr; inv Hs.
+    old_inv Hr; old_inv Hs.
     constructor; simpl; auto; lia.
   Qed.
 
@@ -291,7 +291,7 @@ Section Event_system.
       well_structured (merge (fst r, snd s) (merge r x y) z).
   Proof.
     intros r s x y z Hr Hs.
-    inv Hr; inv Hs.
+    old_inv Hr; old_inv Hs.
     constructor; simpl; auto; lia.
   Qed.
 
@@ -301,12 +301,12 @@ Section Event_system.
                (merge (fst r, snd s) (merge r x y) z).
   Proof.
     intros r s x y z.
-    split; intro; inv H.
+    split; intro; old_inv H.
     - apply prparl; apply prparl; auto.
-    - inv H5.
+    - old_inv H5.
       + apply prparl; apply prparr; auto.
       + apply prparr; auto.
-    - inv H5.
+    - old_inv H5.
       + apply prparl; auto.
       + apply prparr; apply prparl; auto.
     - apply prparr; apply prparr; auto.
@@ -332,7 +332,7 @@ Section Event_system.
       well_structured (before (fst r, snd s) x (before s y z)).
   Proof.
     intros r s x y z Hr Hs.
-    inv Hr; inv Hs.
+    old_inv Hr; old_inv Hs.
     constructor; simpl; auto; lia.
   Qed.
 
@@ -343,7 +343,7 @@ Section Event_system.
       well_structured (before (fst r, snd s) (before r x y) z).
   Proof.
     intros r s x y z Hr Hs.
-    inv Hr; inv Hs.
+    old_inv Hr; old_inv Hs.
     constructor; simpl; auto; lia.
   Qed.
 
@@ -353,19 +353,19 @@ Section Event_system.
                (before (fst r, snd s) (before r x y) z).
   Proof.
     intros r s x y z.
-    split; intro; inv H.
-    - inv H6.
+    split; intro; old_inv H.
+    - old_inv H6.
       + apply prseql; auto.
       + apply prseq; auto.
     - apply prseql; apply prseql; auto.
-    - inv H5.
+    - old_inv H5.
       + apply prseq; auto.
       + apply prseql; apply prseqr; auto.
       + apply prseqr; auto.
-    - inv H5.
+    - old_inv H5.
       + apply prseq; auto.
       + apply prseqr; apply prseq; auto.
-    - inv H5.
+    - old_inv H5.
       + apply prseq; auto.
       + apply prseql; auto.
       + apply prseqr; apply prseql; auto.
@@ -420,7 +420,7 @@ Section Event_system.
       sup (before r x y) e -> sup y e.
   Proof.
     intros.
-    inv H.
+    old_inv H.
     auto.
   Qed.
 
@@ -431,18 +431,18 @@ Section Event_system.
   Proof.
     unfold supreme; split.
     -  induction H; intros.
-       + inv H1.
+       + old_inv H1.
          split; auto; intros; intro.
-         inv H1.
+         old_inv H1.
          apply evsys_irreflexive in H2; auto.
-       + inv H1.
-         inv H3.
+       + old_inv H1.
+         old_inv H3.
          apply IHwell_structured2 in H7.
          destruct H7.
          split.
          * apply ein_beforer; auto.
          * intros; intro.
-           inv H4; inv H5.
+           old_inv H4; old_inv H5.
            -- apply ws_evsys_range in H8; auto.
               apply ws_evsys_range in H12; auto.
               lia.
@@ -463,13 +463,13 @@ Section Event_system.
               lia.
            -- apply H3 in H8.
               tauto.
-       + inv H3.
+       + old_inv H3.
          * apply IHwell_structured1 in H8.
            destruct H8.
            split.
            -- apply ein_mergel; auto.
            -- intros; intro.
-              inv H4; inv H5.
+              old_inv H4; old_inv H5.
               ++ apply H3 in H8; tauto.
               ++ apply prec_in_right in H11.
                  apply ws_evsys_range in H8; auto.
@@ -488,7 +488,7 @@ Section Event_system.
            split.
            -- apply ein_merger; auto.
            -- intros; intro.
-              inv H4; inv H5.
+              old_inv H4; old_inv H5.
               ++ apply prec_in_left in H11.
                  apply ws_evsys_range in H1; auto.
                  apply ws_evsys_range in H11; auto.
@@ -504,8 +504,8 @@ Section Event_system.
               ++ apply H3 in H8; tauto.
     - intro; destruct H0.
       induction H; intros.
-      + inv H0; auto.
-      + inv H0; auto.
+      + old_inv H0; auto.
+      + old_inv H0; auto.
         * cut (exists f, ev_in f y).
           -- intros.
              destruct H0 as [f].
@@ -523,7 +523,7 @@ Section Event_system.
                        (before (fst (es_range x), snd (es_range y)) x y) e e0).
           apply prseqr; auto.
           apply H1 in G; auto; tauto.
-      + inv H0.
+      + old_inv H0.
         * apply IHwell_structured1 in H7; auto.
           intros; intro.
           assert (G: prec

--- a/src/ID_Type.v
+++ b/src/ID_Type.v
@@ -1,15 +1,16 @@
 (* Abstract (Admitted) definition of a general type for 
     Identifiers and associated abstract values/operations *)
 
-Require Export Serializable EqClass.
+Require Export Stringifiable EqClass.
 
 (* Abstract type reserved for Identifiers *)
 Definition ID_Type : Set := string.
 
-(* Serializable Class for ID_Type *)
-Global Instance Serializable_ID_Type : Serializable ID_Type := {
+(* Stringifiable Class for ID_Type *)
+Global Instance Stringifiable_ID_Type : Stringifiable ID_Type := {
   to_string := to_string;
-  from_string := from_string
+  from_string := from_string;
+  canonical_stringification := canonical_stringification
 }.
 
 Global Instance Eq_Class_ID_Type : EqClass ID_Type := {

--- a/src/JSON_Admits.v
+++ b/src/JSON_Admits.v
@@ -4,5 +4,5 @@ Definition JSON_to_string (js : JSON) : string. Admitted.
 
 Definition string_to_JSON (s : string) : ResultT JSON string. Admitted.
 
-Axiom canonical_serialization_json_string : forall (s : string) (js : JSON),
-  (string_to_JSON s) = resultC js <-> (JSON_to_string js = s).
+Axiom canonical_serialization_json_string : forall (js : JSON),
+  string_to_JSON (JSON_to_string js) = resultC js.

--- a/src/Manifest_Admits.v
+++ b/src/Manifest_Admits.v
@@ -1,6 +1,6 @@
 (*  Admitted types, definitions, and typeclass instances related to Manifests *)
 
-Require Import EqClass Term_Defs_Core Serializable.
+Require Import EqClass Term_Defs_Core Stringifiable.
 
 Require Import List.
 Import ListNotations.
@@ -8,13 +8,13 @@ Import ListNotations.
 
 Definition FS_Location : Set. Admitted.
 
-Global Instance Serializable_FS_Location : Serializable FS_Location. Admitted.
+Global Instance Stringifiable_FS_Location : Stringifiable FS_Location. Admitted.
 
 Definition empty_FS_Location : FS_Location. Admitted.
 
 Definition UUID : Type. Admitted.
 
-Global Instance Serializable_UUID : Serializable UUID. Admitted.
+Global Instance Stringifiable_UUID : Stringifiable UUID. Admitted.
 
 (* We need this for making proofs and knowing that yes, in fact, UUID is an inhabited type *)
 Definition default_uuid : UUID. Admitted.
@@ -23,7 +23,7 @@ Global Instance Eq_Class_uuid : EqClass UUID. Admitted.
 
 Definition PublicKey : Set. Admitted.
 
-Global Instance Serializable_PublicKey : Serializable PublicKey. Admitted.
+Global Instance Stringifiable_PublicKey : Stringifiable PublicKey. Admitted.
 
 (* We need this for making proofs and knowing that yes, in fact, PubKey is an inhabited type *)
 Definition default_PubKey : PublicKey. Admitted.

--- a/src/Manifest_Generator_Union.v
+++ b/src/Manifest_Generator_Union.v
@@ -7,7 +7,7 @@ Require Import Term_Defs_Core Params_Admits Manifest Eqb_Evidence
 
 Require Import EqClass Maps StructTactics.
 
-Require Import EnvironmentM Manifest_Set JSON Serializable.
+Require Import EnvironmentM Manifest_Set JSON Stringifiable.
 
 Require Import Manifest_Union Manifest_Generator Cvm_St Cvm_Impl.
 
@@ -121,7 +121,7 @@ Definition knowsof_myPlc_manifest_update (m:Manifest) : Manifest :=
 Definition Evidence_Plc_list := list (Evidence*Plc).
 Open Scope string_scope.
 
-Definition Evidence_Plc_list_to_JSON (ls: Evidence_Plc_list) : JSON :=
+Definition Evidence_Plc_list_to_JSON `{Jsonifiable Evidence} (ls: Evidence_Plc_list) : JSON := 
   JSON_Object [
     ("Evidence_Plc_list",
       (InJSON_Array 
@@ -135,7 +135,7 @@ Definition Evidence_Plc_list_to_JSON (ls: Evidence_Plc_list) : JSON :=
       )
     )].
 
-Definition Evidence_Plc_list_from_JSON (js : JSON) 
+Definition Evidence_Plc_list_from_JSON `{Jsonifiable Evidence} (js : JSON) 
     : ResultT Evidence_Plc_list string :=
   match (JSON_get_Array "Evidence_Plc_list" js) with
   | resultC jsArr =>
@@ -156,14 +156,21 @@ Definition Evidence_Plc_list_from_JSON (js : JSON)
   | errC e => errC e 
   end.
 
-Global Instance Jsonifiable_Evidence_Plc_list : Jsonifiable Evidence_Plc_list := {
-  to_JSON := Evidence_Plc_list_to_JSON;
-  from_JSON := Evidence_Plc_list_from_JSON
-}.
+Global Instance Jsonifiable_Evidence_Plc_list `{Jsonifiable Evidence} : Jsonifiable Evidence_Plc_list.
+eapply Build_Jsonifiable with 
+  (to_JSON := Evidence_Plc_list_to_JSON)
+  (from_JSON := Evidence_Plc_list_from_JSON).
+unfold Evidence_Plc_list_to_JSON, Evidence_Plc_list_from_JSON;
+simpl in *.
+induction a; simpl in *; intuition;
+repeat (try break_match; simpl in *; subst; try congruence);
+repeat rewrite canonical_jsonification in *; try congruence;
+repeat find_injection; eauto.
+Defined.
 
 Definition Term_Plc_list := list (Term*Plc).
 
-Definition Term_Plc_list_to_JSON (ls: Term_Plc_list) : JSON :=
+Definition Term_Plc_list_to_JSON `{Jsonifiable Term} (ls: Term_Plc_list) : JSON :=
   JSON_Object [
     ("Term_Plc_list",
       (InJSON_Array 
@@ -177,7 +184,7 @@ Definition Term_Plc_list_to_JSON (ls: Term_Plc_list) : JSON :=
       )
     )].
 
-Definition Term_Plc_list_from_JSON (js : JSON) 
+Definition Term_Plc_list_from_JSON `{Jsonifiable Term} (js : JSON) 
     : ResultT Term_Plc_list string :=
   match (JSON_get_Array "Term_Plc_list" js) with
   | resultC jsArr =>
@@ -198,10 +205,17 @@ Definition Term_Plc_list_from_JSON (js : JSON)
   | errC e => errC e 
   end.
 
-Global Instance Jsonifiable_Term_Plc_list : Jsonifiable Term_Plc_list := {
-  to_JSON := Term_Plc_list_to_JSON;
-  from_JSON := Term_Plc_list_from_JSON
-}.
+Global Instance Jsonifiable_Term_Plc_list `{Jsonifiable Term} : Jsonifiable Term_Plc_list.
+eapply Build_Jsonifiable with 
+  (to_JSON := Term_Plc_list_to_JSON)
+  (from_JSON := Term_Plc_list_from_JSON).
+unfold Term_Plc_list_from_JSON, Term_Plc_list_to_JSON;
+simpl in *.
+induction a; simpl in *; intuition;
+repeat (try break_match; simpl in *; subst; try congruence);
+repeat rewrite canonical_jsonification in *; try congruence;
+repeat find_injection; eauto.
+Defined.
 
 Definition knowsof_myPlc_manifest_update_env' (p:(Plc*Manifest)) : (Plc*Manifest) := 
   (fst p, (knowsof_myPlc_manifest_update (snd p))).

--- a/src/Manifest_Set.v
+++ b/src/Manifest_Set.v
@@ -303,14 +303,14 @@ Proof.
     + apply manadd_In_set in H; destruct H; subst; auto with *.       
 Qed.
 
-Fixpoint manifest_set_to_list_InJson {A :Type} `{Serializable A} 
-    (m : manifest_set A) : list InnerJSON :=
+Fixpoint manifest_set_to_list_InJson {A :Type} `{Stringifiable A} 
+    `{EqClass A} (m : manifest_set A) : list InnerJSON :=
   match m with
   | nil => []
   | h :: t => (InJSON_String (to_string h)) :: (manifest_set_to_list_InJson t)
   end.
 
-Fixpoint list_InJson_to_manifest_set {A :Type} `{Serializable A} `{EqClass A}
+Fixpoint list_InJson_to_manifest_set {A :Type} `{Stringifiable A} `{EqClass A}
     (l : list InnerJSON) : ResultT (manifest_set A) string :=
   match l with
   | nil => resultC []
@@ -320,25 +320,33 @@ Fixpoint list_InJson_to_manifest_set {A :Type} `{Serializable A} `{EqClass A}
       match (list_InJson_to_manifest_set t) with
       | resultC t' => 
           match (from_string s) with
-          | resultC h' => resultC (manset_add h' t')
+          (* TODO: This should really use a safer add, but man sets arent guarded inductively so in proofs the fact is lost for resolution *)
+          | resultC h' => resultC (h' :: t')
           | errC e => errC e
           end
       | errC e => errC e
       end
-    | _ => errC "Error: Invalid JSON type in manifest set, only can handle strings."%string
+    | _ => errC "list_InJson_to_manifest_set: Invalid JSON type in manifest set, only can handle strings."%string
     end
   end.
 
-Fixpoint manifest_set_pairs_to_list_InJson {A B : Type} `{Serializable A} 
-    `{Serializable B} (m : manifest_set (A * B)) : list InnerJSON :=
+Lemma canonical_list_injson_to_manset {A : Type} `{Stringifiable A} `{EqClass A} (m : manifest_set A) :
+  list_InJson_to_manifest_set (manifest_set_to_list_InJson m) = resultC m.
+Proof.
+  induction m; simpl in *; intuition; eauto;
+  find_rewrite; rewrite canonical_stringification in *; simpl in *; eauto.
+Qed.
+
+Fixpoint manifest_set_pairs_to_list_InJson {A B : Type} `{Stringifiable A} 
+    `{Stringifiable B} (m : manifest_set (A * B)) : list InnerJSON :=
   match m with
   | [] => []
   | h :: t => 
         (pair_to_JSON_Array h) :: (manifest_set_pairs_to_list_InJson t)
   end.
 
-Fixpoint list_InJson_to_manifest_set_pairs {A B :Type} `{Serializable A} 
-    `{Serializable B} `{EqClass A} `{EqClass B}
+Fixpoint list_InJson_to_manifest_set_pairs {A B :Type} `{Stringifiable A} 
+    `{Stringifiable B} `{EqClass A} `{EqClass B}
     (l : list InnerJSON) : ResultT (manifest_set (A * B)) string :=
   match l with
   | nil => resultC []
@@ -346,9 +354,17 @@ Fixpoint list_InJson_to_manifest_set_pairs {A B :Type} `{Serializable A}
     match (InnerJSON_to_pair h) with
     | resultC h' =>
       match (list_InJson_to_manifest_set_pairs t) with
-      | resultC t' => resultC (manset_add h' t')
+      (* TODO: Same here as above, we would like to use add but it doesnt have all we need *)
+      | resultC t' => resultC (h' :: t')
       | errC e => errC e
       end
     | errC e => errC e
     end
   end.
+
+Lemma canonical_list_injson_to_manset_pairs {A B : Type} `{Stringifiable A, Stringifiable B} `{EqClass A, EqClass B} (m : manifest_set (A * B)) :
+  list_InJson_to_manifest_set_pairs (manifest_set_pairs_to_list_InJson m) = resultC m.
+Proof.
+  induction m; simpl in *; intuition; eauto;
+  find_rewrite; repeat rewrite canonical_stringification in *; simpl in *; eauto.
+Qed.

--- a/src/Preamble.v
+++ b/src/Preamble.v
@@ -9,9 +9,11 @@ This proof script is free software: you can redistribute it and/or
 modify it under the terms of the BSD License as published by the
 University of California.  See license.txt for details. *)
 
+Require Export StructTactics.
+
 (** Tactics that provide useful automation. *)
 
-Ltac inv H := inversion H; clear H; subst.
+Ltac old_inv H := inversion H; clear H; subst.
 
 (** Expand let expressions in both the antecedent and the
     conclusion. *)

--- a/src/Serializable_Class_Admits.v
+++ b/src/Serializable_Class_Admits.v
@@ -1,3 +1,0 @@
-Require Import ResultT Serializable.
-
-Global Instance Serializable_nat : Serializable nat. Admitted.

--- a/src/Stringifiable.v
+++ b/src/Stringifiable.v
@@ -1,19 +1,22 @@
 Require Export String ResultT.
 Open Scope string_scope.
 
-Class Serializable (A : Type) :=
+Class Stringifiable (A : Type) :=
   {
     to_string : A -> string;
     from_string : string -> ResultT A string;
+    canonical_stringification : forall a, 
+      from_string (to_string a) = resultC a;
   }.
 
-Global Instance Serializable_string : Serializable string :=
+Global Instance Stringifiable_string : Stringifiable string :=
   {
     to_string := fun s => s;
     from_string := fun s => resultC s;
+    canonical_stringification := fun s => eq_refl;
   }.
 
-Global Instance Serializable_bool : Serializable bool :=
+Global Instance Stringifiable_bool : Stringifiable bool :=
   {
     to_string := fun b => if b then "true" else "false";
     from_string := fun s => 
@@ -22,6 +25,11 @@ Global Instance Serializable_bool : Serializable bool :=
                      | "false" => resultC false
                      | _ => errC "Not a boolean"
                      end;
+    canonical_stringification := fun b =>
+                                   match b with
+                                   | true => eq_refl
+                                   | false => eq_refl
+                                   end;
   }.
 
 Close Scope string_scope.

--- a/src/Stringifiable_Class_Admits.v
+++ b/src/Stringifiable_Class_Admits.v
@@ -1,0 +1,3 @@
+Require Import ResultT Stringifiable.
+
+Global Instance Stringifiable_nat : Stringifiable nat. Admitted.

--- a/src/_CoqProject
+++ b/src/_CoqProject
@@ -1,10 +1,10 @@
 -R . CoplandM
+StructTactics.v
 Preamble.v
 ResultT.v
-Serializable.v
-Serializable_Class_Admits.v
+Stringifiable.v
+Stringifiable_Class_Admits.v
 More_lists.v
-StructTactics.v
 EqClass.v
 ID_Type.v
 Defs.v


### PR DESCRIPTION
This pull request modifies the Jsonifiable and Stringifiable classes to require that they include a proof that $\forall x, from\\_string (to\\_string\ x) = x$ and $\forall x, from\\_json (to\\_json\ x) = x$.

This is essentially encoding the formal property that **solely using our JSON converters will always result in a good encoding and parsing**.